### PR TITLE
CPA-99/bug (Typo bug with data_set_path)

### DIFF
--- a/apprest/services/experiment.py
+++ b/apprest/services/experiment.py
@@ -175,7 +175,7 @@ class CalipsoExperimentsServices:
                 session_end_date = datetime.datetime.strptime(session.get('start_date'), "%Y-%m-%dT%H:%M:%SZ")
                 session_subject = session.get('subject')
                 session_body = session.get('body')
-                session_data_set_path = session.get('date_set_path')
+                session_data_set_path = session.get('data_set_path')
 
                 if not session_data_set_path:
                     session_data_set_path = "[]"


### PR DESCRIPTION
Typo bug with data_set_path

There are a typo graphic error when retrieve data_set_path from the session.

closes #32