### PR TITLE
Bump django in requirements.txt to 2.1.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ requests>=2.20,<2.21
 six==1.11.0
 urllib3>=1.23,<1.24
 websocket-client==0.47.0
-Django==2.1.2
+django==2.1.5
 gunicorn>=19.5.0,<19.6
 django-filter==2.0.0
 mozilla-django-oidc==1.2.1


### PR DESCRIPTION
To get around a bug we encountered (https://code.djangoproject.com/ticket/29182) it is necessary to bump django to 2.1.5.  Fixes issue for us.
Error: sqlite3.OperationalError: no such table: main.auth_user__old