### PR TITLE
Calipsoplus backend fix umbrella 2

### DIFF
--- a/apprest/services/user.py
+++ b/apprest/services/user.py
@@ -14,10 +14,12 @@ class CalipsoUserServices:
     def get_umbrella_session_hash(self, request):
         self.logger.debug('try to get umbrella session')
         try:
-            #session_hash = request.META["HTTP_EAAHASH"]
-            session_hash = request.META["EAAHash"]
-            #uid = request.META["HTTP_UID"]
-            uid = request.META["uid"]
+            if "EAAHash" in request.META:
+                session_hash = request.META["EAAHash"]
+                uid = request.META["uid"]
+            else:
+                session_hash = request.META["HTTP_EAAHASH"]
+                uid = request.META["HTTP_UID"]
 
             json_session_data = {'EAAHash': session_hash, 'uid': uid}
 

--- a/apprest/services/user.py
+++ b/apprest/services/user.py
@@ -14,8 +14,10 @@ class CalipsoUserServices:
     def get_umbrella_session_hash(self, request):
         self.logger.debug('try to get umbrella session')
         try:
-            session_hash = request.META["HTTP_EAAHASH"]
-            uid = request.META["HTTP_UID"]
+            #session_hash = request.META["HTTP_EAAHASH"]
+	    session_hash = request.META["EAAHash"]
+            #uid = request.META["HTTP_UID"]
+	    uid = request.META["uid"]
 
             json_session_data = {'EAAHash': session_hash, 'uid': uid}
 

--- a/apprest/services/user.py
+++ b/apprest/services/user.py
@@ -15,9 +15,9 @@ class CalipsoUserServices:
         self.logger.debug('try to get umbrella session')
         try:
             #session_hash = request.META["HTTP_EAAHASH"]
-	    session_hash = request.META["EAAHash"]
+            session_hash = request.META["EAAHash"]
             #uid = request.META["HTTP_UID"]
-	    uid = request.META["uid"]
+            uid = request.META["uid"]
 
             json_session_data = {'EAAHash': session_hash, 'uid': uid}
 

--- a/apprest/tests/unit/services/test_users.py
+++ b/apprest/tests/unit/services/test_users.py
@@ -20,8 +20,10 @@ class UserServiceTestCase(CalipsoTestCase):
 
         request = HttpRequest()
         request.method = 'GET'
-        request.META['HTTP_EAAHASH'] = eaa_hash
-        request.META["HTTP_UID"] = uid
+        #request.META['HTTP_EAAHASH'] = eaa_hash
+        #request.META["HTTP_UID"] = uid
+        request.META['EAAHash'] = eaa_hash
+        request.META["uid"] = uid
 
         json_umbrella_meta = self.user_service.get_umbrella_session_hash(request)
 


### PR DESCRIPTION
As it is rather difficult to introspect from Django which way the UmbrellaID 
is configured (apache or nginx, Shibboleth with  one setting or the other, 
SimpleSAMLphp, ..., etc.), the change in the code considers the alternative 
possibilities with which the attributes can appear ("EAAHash" vs. 
"HTTP_EAAHASH").
