### PR TITLE
Test both alternative UmbrellaID attribute name forms

### DIFF
--- a/apprest/tests/unit/services/test_users.py
+++ b/apprest/tests/unit/services/test_users.py
@@ -29,16 +29,16 @@ class UserServiceTestCase(CalipsoTestCase):
         self.assertEqual(json_umbrella_meta.get('uid'), uid)
         self.assertEqual(json_umbrella_meta.get('EAAHash'), eaa_hash)
 
-        request1 = HttpRequest()
-        request1.method = 'GET'
+        del request.META['EAAHash']
+        del request.META["uid"]
 
-        request1.META["HTTP_EAAHASH"] = eaa_hash
-        request1.META["HTTP_UID"] = uid
+        request.META["HTTP_EAAHASH"] = eaa_hash
+        request.META["HTTP_UID"] = uid
 
-        json_umbrella_meta1 = self.user_service.get_umbrella_session_hash(request1)
+        json_umbrella_meta = self.user_service.get_umbrella_session_hash(request)
 
-        self.assertEqual(json_umbrella_meta1.get("HTTP_UID"), uid)
-        self.assertEqual(json_umbrella_meta1.get("HTTP_EAAHASH"), eaa_hash)
+        self.assertEqual(json_umbrella_meta.get('uid'), uid)
+        self.assertEqual(json_umbrella_meta.get('EAAHash'), eaa_hash)
 
     def test_lookup_none_existing_umbrella_hash(self):
         self.logger.debug('#################### test_lookup_existing_umbrella_hash ####')

--- a/apprest/tests/unit/services/test_users.py
+++ b/apprest/tests/unit/services/test_users.py
@@ -20,8 +20,7 @@ class UserServiceTestCase(CalipsoTestCase):
 
         request = HttpRequest()
         request.method = 'GET'
-        #request.META['HTTP_EAAHASH'] = eaa_hash
-        #request.META["HTTP_UID"] = uid
+
         request.META['EAAHash'] = eaa_hash
         request.META["uid"] = uid
 
@@ -29,6 +28,17 @@ class UserServiceTestCase(CalipsoTestCase):
 
         self.assertEqual(json_umbrella_meta.get('uid'), uid)
         self.assertEqual(json_umbrella_meta.get('EAAHash'), eaa_hash)
+
+        del request.META["EAAHash"]
+        del request.META["uid"]
+
+        request.META["HTTP_EAAHASH"] = eaa_hash
+        request.META["HTTP_UID"] = uid
+
+        json_umbrella_meta = self.user_service.get_umbrella_session_hash(request)
+
+        self.assertEqual(json_umbrella_meta.get("HTTP_UID"), uid)
+        self.assertEqual(json_umbrella_meta.get("HTTP_EAAHASH"), eaa_hash)
 
     def test_lookup_none_existing_umbrella_hash(self):
         self.logger.debug('#################### test_lookup_existing_umbrella_hash ####')

--- a/apprest/tests/unit/services/test_users.py
+++ b/apprest/tests/unit/services/test_users.py
@@ -29,16 +29,16 @@ class UserServiceTestCase(CalipsoTestCase):
         self.assertEqual(json_umbrella_meta.get('uid'), uid)
         self.assertEqual(json_umbrella_meta.get('EAAHash'), eaa_hash)
 
-        del request.META["EAAHash"]
-        del request.META["uid"]
+        request1 = HttpRequest()
+        request1.method = 'GET'
 
-        request.META["HTTP_EAAHASH"] = eaa_hash
-        request.META["HTTP_UID"] = uid
+        request1.META["HTTP_EAAHASH"] = eaa_hash
+        request1.META["HTTP_UID"] = uid
 
-        json_umbrella_meta = self.user_service.get_umbrella_session_hash(request)
+        json_umbrella_meta1 = self.user_service.get_umbrella_session_hash(request1)
 
-        self.assertEqual(json_umbrella_meta.get("HTTP_UID"), uid)
-        self.assertEqual(json_umbrella_meta.get("HTTP_EAAHASH"), eaa_hash)
+        self.assertEqual(json_umbrella_meta1.get("HTTP_UID"), uid)
+        self.assertEqual(json_umbrella_meta1.get("HTTP_EAAHASH"), eaa_hash)
 
     def test_lookup_none_existing_umbrella_hash(self):
         self.logger.debug('#################### test_lookup_existing_umbrella_hash ####')


### PR DESCRIPTION
I added the test to check the UmbrellaID attributes in both forms: "EAAHash" and "HTTP_EAAHASH".