### PR TITLE
Add ability to mount arbitrary host paths

### DIFF
--- a/apprest/services/resource_docker.py
+++ b/apprest/services/resource_docker.py
@@ -14,6 +14,7 @@ from apprest.services.session import CalipsoSessionsServices
 from apprest.utils.exceptions import DockerExceptionNotFound
 from apprest.services.user import CalipsoUserServices
 from calipsoplus.settings_calipso import ADD_HOME_DIR_TO_ALL_CONTAINERS
+from calipsoplus.settings_calipso import OTHER_DIRS_TO_MOUNT
 
 image_service = CalipsoAvailableImagesServices()
 session_service = CalipsoSessionsServices()
@@ -89,6 +90,12 @@ class CalipsoResourceDockerContainerService:
             volume.update(
                 {str(user_service.get_user_home_dir(username)): {"bind": "/tmp/user/home/", "mode": "rw"}}
             )
+
+        # Check for, and add any additional directories from the docker host
+        if OTHER_DIRS_TO_MOUNT is not None and type(OTHER_DIRS_TO_MOUNT) is list:
+            for _ in OTHER_DIRS_TO_MOUNT:
+                (src_vol,dst_vol,vol_mode) = _.split(':')
+                volume[src_vol] = {"bind" : dst_vol, "mode" : vol_mode}
 
         self.logger.debug('volume set to :%s', volume)
 

--- a/calipsoplus/settings_calipso.py.example
+++ b/calipsoplus/settings_calipso.py.example
@@ -45,3 +45,10 @@ ENABLE_NON_ROOT_GID_CONTAINER = False
 ADD_HOME_DIR_TO_ALL_CONTAINERS = False
 
 API_URL_FOR_UID_AND_GID = 'http://example.fr/user/details'
+
+# Mount arbitrary directories into container
+# Form: "source:target:ro|rw"
+OTHER_DIRS_TO_MOUNT = [
+    "/opt/matlab/2018b:/usr/local/matlab:ro",
+    "/opt/tools:/opt/tools:ro",
+]


### PR DESCRIPTION
Add the OTHER_DIRS_TO_MOUNT option, which
is a list of src,dst,mode to mount from
the docker machine host. This is handy to
bring in larger software apps which would
otherwise be impractical to bundle in a
container. Think Matlab.